### PR TITLE
Move publishType and ivyRepositoryPattern to NexusRepository

### DIFF
--- a/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/BaseNexusPublishPluginTests.kt
+++ b/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/BaseNexusPublishPluginTests.kt
@@ -110,9 +110,9 @@ abstract class BaseNexusPublishPluginTests {
         buildGradle.append(
             """
             nexusPublishing {
-                publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                 repositories {
                     sonatype {
+                        publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                         nexusUrl = uri('${server.baseUrl()}')
                         allowInsecureProtocol = true
                         //No staging profile defined
@@ -161,9 +161,9 @@ abstract class BaseNexusPublishPluginTests {
                 }
             }
             nexusPublishing {
-                publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                 repositories {
                     myNexus {
+                        publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                         nexusUrl = uri('https://example.com')
                     }
                 }
@@ -204,9 +204,9 @@ abstract class BaseNexusPublishPluginTests {
             }
 
             nexusPublishing {
-                publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                 repositories {
                     myNexus {
+                        publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                         nexusUrl = uri('${server.baseUrl()}')
                         snapshotRepositoryUrl = uri('${server.baseUrl()}/snapshots/')
                         allowInsecureProtocol = true
@@ -252,9 +252,9 @@ abstract class BaseNexusPublishPluginTests {
                 }
             }
             nexusPublishing {
-                publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                 repositories {
                     myNexus {
+                        publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                         nexusUrl = uri('${server.baseUrl()}')
                         snapshotRepositoryUrl = uri('${server.baseUrl()}/snapshots/')
                         username = 'username'
@@ -309,9 +309,9 @@ abstract class BaseNexusPublishPluginTests {
                 }
             }
             nexusPublishing {
-                publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                 repositories {
                     myNexus {
+                        publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                         nexusUrl = uri('http://$nonRoutableAddress/')
                         snapshotRepositoryUrl = uri('$nonRoutableAddress/snapshots/')
                         username = 'username'
@@ -351,9 +351,10 @@ abstract class BaseNexusPublishPluginTests {
                 }
             }
             nexusPublishing {
-                publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                 repositories {
-                    sonatype()
+                    sonatype {
+                        publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
+                    }
                 }
             }
             """
@@ -385,9 +386,10 @@ abstract class BaseNexusPublishPluginTests {
                 }
             }
             nexusPublishing {
-                publicationType.set(io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName)
                 repositories {
-                    sonatype()
+                    sonatype {
+                        publicationType.set(io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName)
+                    }
                 }
             }
             """
@@ -515,9 +517,9 @@ abstract class BaseNexusPublishPluginTests {
         buildGradle.append(
             """
             nexusPublishing {
-                publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                 repositories {
                     sonatype {
+                        publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                         nexusUrl = uri('${server.baseUrl()}')
                         allowInsecureProtocol = true
                         //No staging profile defined
@@ -582,9 +584,9 @@ abstract class BaseNexusPublishPluginTests {
         projectDir.resolve("build.gradle").append(
             """
             nexusPublishing {
-                publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                 repositories {
                     remove(create("myNexus") {
+                        publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                         nexusUrl = uri('${server.baseUrl()}/b/')
                         snapshotRepositoryUrl = uri('${server.baseUrl()}/b/snapshots/')
                     })
@@ -749,9 +751,9 @@ abstract class BaseNexusPublishPluginTests {
         buildGradle.append(
             """
             nexusPublishing {
-                publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                 repositories {
                     sonatype {
+                        publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                         nexusUrl = uri('${server.baseUrl()}')
                         allowInsecureProtocol = true
                         username = 'username'

--- a/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/IvyNexusPublishPluginTests.kt
+++ b/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/IvyNexusPublishPluginTests.kt
@@ -57,9 +57,9 @@ class IvyNexusPublishPluginTests : BaseNexusPublishPluginTests() {
                 }
             }
             nexusPublishing {
-                publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                 repositories {
                     myNexus {
+                        publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                         nexusUrl = uri('${server.baseUrl()}/shouldNotBeUsed')
                         snapshotRepositoryUrl = uri('${server.baseUrl()}/snapshots')
                         allowInsecureProtocol = true
@@ -103,11 +103,6 @@ class IvyNexusPublishPluginTests : BaseNexusPublishPluginTests() {
                 }
             }
             nexusPublishing {
-                ivyPatternLayout {
-                    artifact "[organisation]/[module]_foo/[revision]/[artifact]-[revision](-[classifier])(.[ext])"
-                    m2compatible = true
-                }
-                publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                 repositories {
                     myNexus {
                         nexusUrl = uri('${server.baseUrl()}/shouldNotBeUsed')
@@ -115,6 +110,12 @@ class IvyNexusPublishPluginTests : BaseNexusPublishPluginTests() {
                         allowInsecureProtocol = true
                         username = 'username'
                         password = 'password'
+
+                         ivyPatternLayout {
+                            artifact "[organisation]/[module]_foo/[revision]/[artifact]-[revision](-[classifier])(.[ext])"
+                            m2compatible = true
+                        }
+                        publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                     }
                 }
             }
@@ -156,9 +157,9 @@ class IvyNexusPublishPluginTests : BaseNexusPublishPluginTests() {
                 }
             }
             nexusPublishing {
-                publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                 repositories {
                     myNexus {
+                        publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                         nexusUrl = uri('${server.baseUrl()}')
                         snapshotRepositoryUrl = uri('${server.baseUrl()}/snapshots/')
                         allowInsecureProtocol = true
@@ -166,6 +167,7 @@ class IvyNexusPublishPluginTests : BaseNexusPublishPluginTests() {
                         password = 'password'
                     }
                     someOtherNexus {
+                        publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                         nexusUrl = uri('${otherServer.baseUrl()}')
                         snapshotRepositoryUrl = uri('${otherServer.baseUrl()}/snapshots/')
                         allowInsecureProtocol = true
@@ -247,9 +249,9 @@ class IvyNexusPublishPluginTests : BaseNexusPublishPluginTests() {
                 }
             }
             nexusPublishing {
-                publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                 repositories {
                     myNexus {
+                        publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                         nexusUrl = uri('${server.baseUrl()}')
                         snapshotRepositoryUrl = uri('${server.baseUrl()}/snapshots/')
                         allowInsecureProtocol = true
@@ -305,9 +307,9 @@ class IvyNexusPublishPluginTests : BaseNexusPublishPluginTests() {
                 id('io.github.gradle-nexus.publish-plugin')
             }
             nexusPublishing {
-                publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                 repositories {
                     sonatype {
+                        publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                         nexusUrl = uri('${server.baseUrl()}')
                         stagingProfileId = '$STAGING_PROFILE_ID'
                         allowInsecureProtocol = true

--- a/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/MavenNexusPublishPluginTests.kt
+++ b/src/compatTest/kotlin/io/github/gradlenexus/publishplugin/MavenNexusPublishPluginTests.kt
@@ -57,9 +57,9 @@ class MavenNexusPublishPluginTests : BaseNexusPublishPluginTests() {
                 }
             }
             nexusPublishing {
-                publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                 repositories {
                     myNexus {
+                        publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                         nexusUrl = uri('${server.baseUrl()}/shouldNotBeUsed')
                         snapshotRepositoryUrl = uri('${server.baseUrl()}/snapshots')
                         allowInsecureProtocol = true
@@ -106,9 +106,9 @@ class MavenNexusPublishPluginTests : BaseNexusPublishPluginTests() {
                 }
             }
             nexusPublishing {
-                publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                 repositories {
                     myNexus {
+                        publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                         nexusUrl = uri('${server.baseUrl()}')
                         snapshotRepositoryUrl = uri('${server.baseUrl()}/snapshots/')
                         allowInsecureProtocol = true
@@ -196,9 +196,9 @@ class MavenNexusPublishPluginTests : BaseNexusPublishPluginTests() {
                 }
             }
             nexusPublishing {
-                publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                 repositories {
                     myNexus {
+                        publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                         nexusUrl = uri('${server.baseUrl()}')
                         snapshotRepositoryUrl = uri('${server.baseUrl()}/snapshots/')
                         allowInsecureProtocol = true
@@ -254,9 +254,9 @@ class MavenNexusPublishPluginTests : BaseNexusPublishPluginTests() {
                 id('io.github.gradle-nexus.publish-plugin')
             }
             nexusPublishing {
-                publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                 repositories {
                     sonatype {
+                        publicationType = io.github.gradlenexus.publishplugin.NexusPublishExtension.PublicationType.$publicationTypeName
                         nexusUrl = uri('${server.baseUrl()}')
                         stagingProfileId = '$STAGING_PROFILE_ID'
                         allowInsecureProtocol = true

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExtension.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusPublishExtension.kt
@@ -20,8 +20,6 @@ import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.NamedDomainObjectFactory
 import org.gradle.api.Project
-import org.gradle.api.artifacts.repositories.IvyPatternRepositoryLayout
-import org.gradle.api.provider.Property
 import org.gradle.api.publish.Publication
 import org.gradle.api.publish.ivy.IvyPublication
 import org.gradle.api.publish.ivy.tasks.PublishToIvyRepository
@@ -73,13 +71,6 @@ open class NexusPublishExtension(project: Project) {
             }
         )
     )
-
-    val publicationType: Property<PublicationType> = project.objects.property<PublicationType>().value(PublicationType.MAVEN)
-
-    val ivyPatternLayout: Property<Action<IvyPatternRepositoryLayout>> = project.objects.property<Action<IvyPatternRepositoryLayout>>()
-    fun ivyPatternLayout(action: Action<IvyPatternRepositoryLayout>) {
-        ivyPatternLayout.set(action)
-    }
 
     fun repositories(action: Action<in NexusRepositoryContainer>) = action.execute(repositories)
 

--- a/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusRepository.kt
+++ b/src/main/kotlin/io/github/gradlenexus/publishplugin/NexusRepository.kt
@@ -16,7 +16,10 @@
 
 package io.github.gradlenexus.publishplugin
 
+import org.gradle.api.Action
 import org.gradle.api.Project
+import org.gradle.api.artifacts.repositories.IvyPatternRepositoryLayout
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
@@ -32,6 +35,9 @@ open class NexusRepository @Inject constructor(@Input val name: String, project:
 
     @Input
     val snapshotRepositoryUrl = project.objects.property<URI>()
+
+    @Input
+    val publicationType: Property<NexusPublishExtension.PublicationType> = project.objects.property<NexusPublishExtension.PublicationType>().value(NexusPublishExtension.PublicationType.MAVEN)
 
     @Internal
     val username = project.objects.property<String>().apply {
@@ -52,4 +58,11 @@ open class NexusRepository @Inject constructor(@Input val name: String, project:
 
     @get:Internal
     internal val capitalizedName by lazy { name.capitalize() }
+
+    @Optional
+    @Input
+    val ivyPatternLayout: Property<Action<IvyPatternRepositoryLayout>> = project.objects.property<Action<IvyPatternRepositoryLayout>>()
+    fun ivyPatternLayout(action: Action<IvyPatternRepositoryLayout>) {
+        ivyPatternLayout.set(action)
+    }
 }


### PR DESCRIPTION
It makes more sense to have these properties configured on an individual repository level rather than at the plugin level This will allow the configuration of repositories with different publication types and repository layouts, mimics the original gradle configuration more closely